### PR TITLE
nearby stations in search

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <application
         android:name="${applicationName}"
         android:label="Treninoo"

--- a/lib/cubit/nearby_stations.dart
+++ b/lib/cubit/nearby_stations.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:treninoo/utils/nearby_stations_service.dart';
+
+// --- States ---
+
+abstract class NearbyStationsState extends Equatable {
+  @override
+  List<Object?> get props => [];
+}
+
+class NearbyStationsInitial extends NearbyStationsState {}
+
+class NearbyStationsLoading extends NearbyStationsState {}
+
+class NearbyStationsSuccess extends NearbyStationsState {
+  final List<NearbyStation> stations;
+
+  NearbyStationsSuccess({required this.stations});
+
+  @override
+  List<Object?> get props => [stations];
+}
+
+/// Location permission was denied or location services are off.
+class NearbyStationsUnavailable extends NearbyStationsState {}
+
+class NearbyStationsFailed extends NearbyStationsState {}
+
+// --- Cubit ---
+
+class NearbyStationsCubit extends Cubit<NearbyStationsState> {
+  NearbyStationsCubit() : super(NearbyStationsInitial());
+
+  Future<void> loadNearbyStations() async {
+    _safeEmit(NearbyStationsLoading());
+    try {
+      final stations = await NearbyStationsService.getNearbyStations(limit: 5);
+      if (stations.isEmpty) {
+        _safeEmit(NearbyStationsUnavailable());
+      } else {
+        _safeEmit(NearbyStationsSuccess(stations: stations));
+      }
+    } catch (e) {
+      _safeEmit(NearbyStationsFailed());
+    }
+  }
+
+  void _safeEmit(NearbyStationsState state) {
+    if (!isClosed) emit(state);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:treninoo/app.dart';
 import 'package:treninoo/repository/saved_solution.dart';
 import 'package:treninoo/repository/saved_station.dart';
 import 'package:treninoo/repository/saved_train.dart';
+import 'package:treninoo/utils/nearby_stations_service.dart';
 import 'package:treninoo/utils/shared_preference.dart';
 import 'package:treninoo/utils/utils.dart';
 
@@ -49,6 +50,9 @@ void main() async {
   SavedStationsRepository savedStationRepository = APISavedStation(sharedPrefs);
   SavedSolutionInfoRepository savedSolutionInfoRepository =
       APISavedSolution(sharedPrefs);
+
+  // Initialize NearbyStationsService with server cache
+  NearbyStationsService.initialize(trainRepository.dio, sharedPrefs);
 
   if (Platform.isAndroid) {
     DeviceInfoPlugin deviceInfoPlugin = DeviceInfoPlugin();

--- a/lib/model/Strike.dart
+++ b/lib/model/Strike.dart
@@ -16,7 +16,6 @@ class Strike extends Equatable {
   });
 
   factory Strike.fromJson(Map<String, dynamic> json) {
-    print(json);
     return Strike(
       startDate:
           json['startDate'] != null ? DateTime.parse(json['startDate']) : null,

--- a/lib/utils/endpoint.dart
+++ b/lib/utils/endpoint.dart
@@ -16,4 +16,5 @@ class Endpoint {
   static const String TRAIN_INFO_VIAGGIOTRENO = '$prefix/details';
   static const String TRAIN_STATUS_ITALO = '$prefix/italo';
   static const String NEWS = '$prefix/news';
+  static const String STATIONS_SYNC = '$prefix/stations/sync';
 }

--- a/lib/utils/location_service.dart
+++ b/lib/utils/location_service.dart
@@ -1,0 +1,28 @@
+import 'package:geolocator/geolocator.dart';
+
+class LocationService {
+  /// Checks if location services are available and permissions are granted.
+  /// Returns the current [Position] or `null` if unavailable.
+  static Future<Position?> getCurrentPosition() async {
+    bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) return null;
+
+    LocationPermission permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) return null;
+    }
+
+    if (permission == LocationPermission.deniedForever) return null;
+
+    try {
+      return await Geolocator.getCurrentPosition(
+        locationSettings: const LocationSettings(
+          accuracy: LocationAccuracy.medium,
+        ),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/utils/nearby_stations_service.dart
+++ b/lib/utils/nearby_stations_service.dart
@@ -1,0 +1,206 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/services.dart';
+import 'package:treninoo/model/Station.dart';
+import 'package:treninoo/utils/location_service.dart';
+import 'package:treninoo/utils/shared_preference.dart';
+import 'package:treninoo/utils/endpoint.dart';
+
+class NearbyStation {
+  final Station station;
+  final double distanceKm;
+
+  NearbyStation({required this.station, required this.distanceKm});
+}
+
+class NearbyStationsService {
+  static Dio? _dio;
+  static SharedPrefs? _sharedPrefs;
+  static List<Map<String, dynamic>>? _stationsCache;
+
+  /// Initializes the service (call once during app init).
+  static void initialize(Dio dio, SharedPrefs sharedPrefs) {
+    _dio = dio;
+    _sharedPrefs = sharedPrefs;
+  }
+
+  /// Syncs station data with the server using hash-based validation.
+  ///
+  /// Sends the locally cached hash to GET /stations/sync?hash=HASH.
+  /// - If the server responds { status: 'ok' }, the local data is current.
+  /// - If the server responds { status: 'updated', hash, data }, saves
+  ///   the new data and hash to SharedPreferences.
+  /// - Falls back to local cache or bundled JSON on any error.
+  static Future<List<Map<String, dynamic>>> _loadStationDatabase() async {
+    if (_stationsCache != null) return _stationsCache!;
+
+    if (_dio == null || _sharedPrefs == null) {
+      return _loadFallbackDatabase();
+    }
+
+    try {
+      final cachedHash = _sharedPrefs!.cachedStationsHash ?? '';
+
+      final response = await _dio!.get(
+        Endpoint.STATIONS_SYNC,
+        queryParameters: {'hash': cachedHash},
+      );
+
+      final data = response.data as Map<String, dynamic>;
+
+      if (data['status'] == 'ok') {
+        // Server confirmed our data is current — use local cache
+        final cached = _getCachedStations();
+        if (cached.isNotEmpty) {
+          _stationsCache = cached;
+          return cached;
+        }
+        // Hash exists but no local data — clear stale hash and force re-fetch
+        _sharedPrefs!.cachedStationsHash = null;
+        final freshResponse = await _dio!.get(
+          Endpoint.STATIONS_SYNC,
+          queryParameters: {'hash': ''},
+        );
+        final freshData = freshResponse.data as Map<String, dynamic>;
+        if (freshData['status'] == 'updated') {
+          final stations = List<Map<String, dynamic>>.from(
+            (freshData['data'] as List).map((s) => s as Map<String, dynamic>),
+          );
+          _updateCache(stations, freshData['hash'] as String);
+          _stationsCache = stations;
+          return stations;
+        }
+        return _loadFallbackDatabase();
+      }
+
+      if (data['status'] == 'updated') {
+        // Server sent new data
+        final stations = List<Map<String, dynamic>>.from(
+          (data['data'] as List).map((s) => s as Map<String, dynamic>),
+        );
+        final newHash = data['hash'] as String;
+        _updateCache(stations, newHash);
+        _stationsCache = stations;
+        return stations;
+      }
+
+      // Unexpected response
+      return _getCachedOrFallback();
+    } catch (e) {
+      return _getCachedOrFallback();
+    }
+  }
+
+  /// Loads the bundled fallback JSON for development or offline use.
+  static Future<List<Map<String, dynamic>>> _loadFallbackDatabase() async {
+    try {
+      final jsonString =
+          await rootBundle.loadString('assets/data/stations_coordinates.json');
+      final List<dynamic> decoded = jsonDecode(jsonString);
+      _stationsCache = decoded.cast<Map<String, dynamic>>();
+      return _stationsCache!;
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /// Returns cached stations from SharedPreferences, or falls back to
+  /// the bundled JSON.
+  static Future<List<Map<String, dynamic>>> _getCachedOrFallback() async {
+    final cached = _getCachedStations();
+    if (cached.isNotEmpty) {
+      _stationsCache = cached;
+      return cached;
+    }
+    return _loadFallbackDatabase();
+  }
+
+  /// Reads cached station JSON from SharedPreferences.
+  static List<Map<String, dynamic>> _getCachedStations() {
+    final raw = _sharedPrefs?.cachedStationsData;
+    if (raw == null) return [];
+    try {
+      final List<dynamic> decoded = jsonDecode(raw);
+      return decoded.cast<Map<String, dynamic>>();
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /// Persists station data and its hash to SharedPreferences.
+  static void _updateCache(List<Map<String, dynamic>> stations, String hash) {
+    _sharedPrefs?.cachedStationsData = jsonEncode(stations);
+    _sharedPrefs?.cachedStationsHash = hash;
+  }
+
+  /// Returns the nearest stations to the user's current GPS position.
+  /// All computation is done on-device — no location data is sent anywhere.
+  static Future<List<NearbyStation>> getNearbyStations({
+    int limit = 5,
+  }) async {
+    final position = await LocationService.getCurrentPosition();
+    if (position == null) return [];
+
+    final stations = await _loadStationDatabase();
+
+    final List<NearbyStation> withDistances = stations.where((s) {
+      final name = s['stationName']?.toString().trim();
+      return name != null && name.isNotEmpty;
+    }).map((s) {
+      final distance = _haversineKm(
+        position.latitude,
+        position.longitude,
+        double.parse(s['lat'].toString()),
+        double.parse(s['lng'].toString()),
+      );
+      String capitalizeName(String? text) {
+        if (text == null || text.isEmpty) return '';
+        return text.split(' ').map((word) {
+          if (word.isEmpty) return word;
+          return "${word[0].toUpperCase()}${word.substring(1).toLowerCase()}";
+        }).join(' ');
+      }
+
+      return NearbyStation(
+        station: Station(
+          stationName: capitalizeName(s['stationName']?.toString()),
+          // Use lefrecceStationCode if available (for API compatibility), fallback to stationCode
+          stationCode: s['lefrecceStationCode'] ?? s['stationCode'],
+        ),
+        distanceKm: distance,
+      );
+    }).toList();
+
+    withDistances.sort((a, b) => a.distanceKm.compareTo(b.distanceKm));
+
+    return withDistances.take(limit).toList();
+  }
+
+  /// Haversine formula — computes the great-circle distance in km between
+  /// two points given their latitude and longitude in degrees.
+  static double _haversineKm(
+    double lat1,
+    double lon1,
+    double lat2,
+    double lon2,
+  ) {
+    const earthRadiusKm = 6371.0;
+
+    final dLat = _degToRad(lat2 - lat1);
+    final dLon = _degToRad(lon2 - lon1);
+
+    final a = sin(dLat / 2) * sin(dLat / 2) +
+        cos(_degToRad(lat1)) *
+            cos(_degToRad(lat2)) *
+            sin(dLon / 2) *
+            sin(dLon / 2);
+
+    final c = 2 * atan2(sqrt(a), sqrt(1 - a));
+
+    return earthRadiusKm * c;
+  }
+
+  static double _degToRad(double deg) => deg * (pi / 180);
+}

--- a/lib/utils/shared_preference.dart
+++ b/lib/utils/shared_preference.dart
@@ -12,6 +12,8 @@ class SharedPrefs {
   static const String SPRecentsAndFavouritesStations =
       'recents-and-favourites-stations';
   static const String SPrecentsSolutions = 'recents-solutions';
+  static const String SPCachedStationsData = 'cached_stations_data';
+  static const String SPCachedStationsHash = 'cached_stations_hash';
 
   Future<void> setup() async {
     _sharedPrefs = await SharedPreferences.getInstance();
@@ -66,5 +68,27 @@ class SharedPrefs {
 
   set recentsSolutions(String? value) {
     _sharedPrefs.setString(SPrecentsSolutions, value!);
+  }
+
+  String? get cachedStationsData =>
+      _sharedPrefs.getString(SPCachedStationsData);
+
+  set cachedStationsData(String? value) {
+    if (value == null) {
+      _sharedPrefs.remove(SPCachedStationsData);
+      return;
+    }
+    _sharedPrefs.setString(SPCachedStationsData, value);
+  }
+
+  String? get cachedStationsHash =>
+      _sharedPrefs.getString(SPCachedStationsHash);
+
+  set cachedStationsHash(String? value) {
+    if (value == null) {
+      _sharedPrefs.remove(SPCachedStationsHash);
+      return;
+    }
+    _sharedPrefs.setString(SPCachedStationsHash, value);
   }
 }

--- a/lib/view/components/dialog/station_picker.dart
+++ b/lib/view/components/dialog/station_picker.dart
@@ -4,8 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:treninoo/bloc/stations/stations.dart';
 import 'package:treninoo/bloc/stations_autocomplete/stations_autocomplete.dart';
+import 'package:treninoo/cubit/nearby_stations.dart';
 import 'package:treninoo/model/Station.dart';
 import 'package:treninoo/repository/train.dart';
+import 'package:treninoo/view/components/stations/nearby_stations_list.dart';
 import 'package:treninoo/view/components/stations/saved_stations_list.dart';
 import 'package:treninoo/view/components/stations/stations_list.dart';
 import 'package:treninoo/view/components/textfield.dart';
@@ -29,10 +31,17 @@ class StationPickerDialog {
           top: Radius.circular(kRadius),
         ),
       ),
-      builder: (_) => BlocProvider(
-        create: (context) => StationsAutocompleteBloc(
-          context.read<TrainRepository>(),
-        ),
+      builder: (_) => MultiBlocProvider(
+        providers: [
+          BlocProvider(
+            create: (context) => StationsAutocompleteBloc(
+              context.read<TrainRepository>(),
+            ),
+          ),
+          BlocProvider(
+            create: (_) => NearbyStationsCubit()..loadNearbyStations(),
+          ),
+        ],
         child: StationPickerContent(type: type),
       ),
     );
@@ -141,8 +150,10 @@ class _StationPickerContentState extends State<StationPickerContent> {
                 SizedBox(height: kPadding),
                 if (searchController.text.isNotEmpty)
                   StationsList(onSelected: selectStation),
-                if (searchController.text.isEmpty)
+                if (searchController.text.isEmpty) ...[
+                  NearbyStationsList(onSelected: selectStation),
                   SavedStationsList(onSelected: selectStation),
+                ],
               ],
             ),
           ),

--- a/lib/view/components/stations/nearby_stations_list.dart
+++ b/lib/view/components/stations/nearby_stations_list.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:treninoo/cubit/nearby_stations.dart';
+import 'package:treninoo/model/Station.dart';
+import 'package:treninoo/repository/saved_station.dart';
+import 'package:treninoo/view/components/beautiful_card.dart';
+import 'package:treninoo/view/style/colors/grey.dart';
+import 'package:treninoo/view/style/theme.dart';
+import 'package:treninoo/view/style/typography.dart';
+import 'package:treninoo/view/router/routes_names.dart';
+
+class NearbyStationsList extends StatelessWidget {
+  final Function(Station) onSelected;
+
+  /// If true, navigates to station page instead of calling onSelected callback.
+  /// Useful for direct usage on pages (not in pickers/dialogs).
+  final bool autoNavigate;
+
+  const NearbyStationsList({
+    Key? key,
+    required this.onSelected,
+    this.autoNavigate = false,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<NearbyStationsCubit, NearbyStationsState>(
+      builder: (context, state) {
+        if (state is NearbyStationsLoading) {
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: kPadding),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.near_me_rounded, size: 16, color: Grey.dark),
+                    SizedBox(width: 6),
+                    Text(
+                      "Stazioni vicine",
+                      style: Typo.bodyHeavy.copyWith(color: Grey.dark),
+                    ),
+                  ],
+                ),
+                SizedBox(height: 8),
+                Center(
+                  child: SizedBox(
+                    height: 24,
+                    width: 24,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                ),
+              ],
+            ),
+          );
+        }
+
+        if (state is NearbyStationsSuccess && state.stations.isNotEmpty) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(Icons.near_me_rounded, size: 16, color: Grey.dark),
+                  SizedBox(width: 6),
+                  Text(
+                    "Stazioni vicine",
+                    style: Typo.bodyHeavy.copyWith(color: Grey.dark),
+                  ),
+                ],
+              ),
+              SizedBox(height: 8),
+              BeautifulCard(
+                child: ListView.separated(
+                  shrinkWrap: true,
+                  physics: NeverScrollableScrollPhysics(),
+                  itemCount: state.stations.length,
+                  separatorBuilder: (_, __) => Divider(thickness: 1, height: 1),
+                  itemBuilder: (context, index) {
+                    final nearby = state.stations[index];
+
+                    return _NearbyStationCard(
+                      station: nearby.station,
+                      distanceKm: nearby.distanceKm,
+                      onPressed: () {
+                        context
+                            .read<SavedStationsRepository>()
+                            .addRecentOrFavoruiteStation(nearby.station);
+
+                        if (autoNavigate) {
+                          // Navigate to station status page and fetch data,
+                          // following the same pattern as favourited/searched stations
+                          Navigator.pushNamed(
+                            context,
+                            RoutesNames.station,
+                            arguments: nearby.station,
+                          );
+                        } else {
+                          // Use callback for picker dialog context
+                          onSelected(nearby.station);
+                        }
+                      },
+                    );
+                  },
+                ),
+              ),
+              SizedBox(height: kPadding),
+            ],
+          );
+        }
+
+        // For initial / unavailable / failed states, show nothing
+        return SizedBox.shrink();
+      },
+    );
+  }
+}
+
+class _NearbyStationCard extends StatelessWidget {
+  final Station station;
+  final double distanceKm;
+  final VoidCallback onPressed;
+
+  const _NearbyStationCard({
+    required this.station,
+    required this.distanceKm,
+    required this.onPressed,
+  });
+
+  String get _formattedDistance {
+    if (distanceKm < 1) {
+      return '${(distanceKm * 1000).round()} m';
+    }
+    return '${distanceKm.toStringAsFixed(1)} km';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: onPressed,
+      style: TextButton.styleFrom(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.zero),
+        padding: EdgeInsets.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      ),
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: kPadding,
+          vertical: kPadding * 1.2,
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Row(
+                children: [
+                  Flexible(
+                    child: Text(
+                      station.stationName,
+                      style: Typo.subheaderHeavy.copyWith(
+                        color: Theme.of(context).colorScheme.onSurface,
+                      ),
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(width: 8),
+            Text(
+              _formattedDistance,
+              style: Typo.bodyLight.copyWith(color: Grey.dark),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/components/stations/saved_stations_list.dart
+++ b/lib/view/components/stations/saved_stations_list.dart
@@ -38,11 +38,15 @@ class _SavedStationsListState extends State<SavedStationsList> {
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisAlignment: MainAxisAlignment.start,
               children: <Widget>[
-                Text(
-                  "Stazioni preferite e recenti",
-                  style: Typo.bodyHeavy.copyWith(
-                    color: Grey.dark,
-                  ),
+                Row(
+                  children: [
+                    Icon(Icons.favorite_rounded, size: 16, color: Grey.dark),
+                    SizedBox(width: 6),
+                    Text(
+                      "Stazioni preferite e recenti",
+                      style: Typo.bodyHeavy.copyWith(color: Grey.dark),
+                    ),
+                  ],
                 ),
                 SizedBox(height: 8),
                 Flexible(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   syncfusion_flutter_datepicker: ^32.2.9
   bloc_concurrency: ^0.3.0
   device_info_plus: ^12.3.0
+  geolocator: ^13.0.2
   google_fonts: ^8.0.2
 
 dev_dependencies:


### PR DESCRIPTION
This pull request introduces a "Nearby Stations" feature, allowing users to see train stations closest to their current location. It includes new location permissions, a on-device station database with server sync and caching, UI integration in the station picker dialog, and all supporting utilities.

**Nearby stations feature and infrastructure:**

* Added `NearbyStationsService` for fetching, caching, and syncing station data with the server, including fallback to bundled JSON and on-device distance calculation using the Haversine formula (`lib/utils/nearby_stations_service.dart`, `lib/utils/endpoint.dart`, `lib/utils/shared_preference.dart`) [[1]](diffhunk://#diff-acb4a02ad7404b097fc1017fc567d9bc18963ad2ef94513480b43dcf97b1906fR1-R206) [[2]](diffhunk://#diff-8b11dfadb2ba5a9ca1cc42a029192f12ae461d39f59754d3db88f18c820e330fR19) [[3]](diffhunk://#diff-7c3ca1082ef399aa575405c6a2e65b08df9bf9f3939c96403231d019eb5515c5R15-R16) [[4]](diffhunk://#diff-7c3ca1082ef399aa575405c6a2e65b08df9bf9f3939c96403231d019eb5515c5R72-R93).
* Implemented `LocationService` for requesting and checking location permissions and retrieving the user's position (`lib/utils/location_service.dart`).
* Added location permissions to `AndroidManifest.xml` and updated dependencies to include `geolocator` (`android/app/src/main/AndroidManifest.xml`, `pubspec.yaml`) [[1]](diffhunk://#diff-63272c98a6330850888e633b43ba4c9decee6431a115e0d2731564838eaa1d1dR3-R4) [[2]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R38).

**State management and UI integration:**

* Introduced `NearbyStationsCubit` and related states for managing nearby stations loading and error handling (`lib/cubit/nearby_stations.dart`).
* Integrated the nearby stations list into the station picker dialog UI, including a new `NearbyStationsList` widget and logic to display it when the search field is empty (`lib/view/components/dialog/station_picker.dart`, `lib/view/components/stations/nearby_stations_list.dart`) [[1]](diffhunk://#diff-4289a58151bf3002e33085a3112091c8864ba430de2b0c4aa7379361c1bcb3d5R7-R10) [[2]](diffhunk://#diff-4289a58151bf3002e33085a3112091c8864ba430de2b0c4aa7379361c1bcb3d5L32-R44) [[3]](diffhunk://#diff-4289a58151bf3002e33085a3112091c8864ba430de2b0c4aa7379361c1bcb3d5L144-R157) [[4]](diffhunk://#diff-b26af32bfa2f6688349c007b5da60ba2c2fb7ee24d648177a1237df044bc1a5cR1-R178).

**Other changes and improvements:**

* Improved the saved stations list UI with an icon for clarity (`lib/view/components/stations/saved_stations_list.dart`).
* Removed a debug print statement from the `Strike` model (`lib/model/Strike.dart`).
* Ensured proper initialization of the new service at app startup (`lib/main.dart`) [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R13) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R54-R56).

These changes together provide users with a seamless way to quickly select nearby stations, with robust handling for offline use and location permissions.